### PR TITLE
Normalize area title.

### DIFF
--- a/src/interlegis/portalmodelo/ombudsman/content/ombudsoffice.py
+++ b/src/interlegis/portalmodelo/ombudsman/content/ombudsoffice.py
@@ -3,6 +3,8 @@
 from interlegis.portalmodelo.ombudsman.interfaces import IOmbudsOffice
 from five import grok
 from plone.dexterity.content import Container
+from zope.component import queryUtility
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 
 
 class OmbudsOffice(Container):
@@ -13,4 +15,5 @@ class OmbudsOffice(Container):
     def get_emails_for_areas(self):
         """Return a dictionary with areas as keys and emails as values.
         """
-        return dict((i['area'], i['email']) for i in self.areas)
+        return dict((queryUtility(IIDNormalizer).normalize(i['area']),
+                     i['email']) for i in self.areas)

--- a/src/interlegis/portalmodelo/ombudsman/tests/test_ombudsoffice.py
+++ b/src/interlegis/portalmodelo/ombudsman/tests/test_ombudsoffice.py
@@ -8,6 +8,7 @@ from plone.dexterity.interfaces import IDexterityFTI
 from plone.uuid.interfaces import IAttributeUUID
 from zope.component import createObject
 from zope.component import queryUtility
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 
 import unittest
 
@@ -57,8 +58,9 @@ class OmbudsOfficeTestCase(unittest.TestCase):
 
     def test_get_emails_for_areas(self):
         self.office.areas = [
-            dict(responsible='John Doe', email='foo@bar.com', area='area1'),
-            dict(responsible='Mary Doe', email='baz@qux.com', area='area2'),
+            dict(responsible='John Doe', email='foo@bar.com', area='Area 1 Title'),
+            dict(responsible='Mary Doe', email='baz@qux.com', area='Area 2 Title'),
         ]
-        expected = dict(area1='foo@bar.com', area2='baz@qux.com')
+        expected = {'area-1-title': 'foo@bar.com', 'area-2-title': 'baz@qux.com'}
         self.assertDictEqual(self.office.get_emails_for_areas(), expected)
+


### PR DESCRIPTION
Normalize area title so the Choice value can be used to find respective email address. fix #9
